### PR TITLE
Spiffed up the script so it behaves a little better

### DIFF
--- a/addSongToCurrentPlayList.py
+++ b/addSongToCurrentPlayList.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #-*- coding: UTF-8 -*-
 
 import requests
@@ -46,12 +46,18 @@ def addOneSong(url):
 </playlist>
 """)
 
-    os.system("/usr/bin/clementine -a /tmp/song.xspf")
+    os.system("clementine -a /tmp/song.xspf")
     return
 
 if (len(sys.argv) > 1 ):
     addOneSong(sys.argv[1])
 
 while(True):
-    for uri in input("Uri: ").split(" "):
-        addOneSong(uri)
+    try:
+        for uri in input("Uri: ").split(" "):
+            if not uri.strip() == "": # blank lines ignored
+                addOneSong(uri)
+    except (KeyboardInterrupt, EOFError): # ^C, ^D
+        sys.stdout.write("\r       \r") # clear line before printing
+        print("Bye")
+        sys.exit(0)


### PR DESCRIPTION
- Changed #! line to use `/usr/bin/env python3` instead, to allow the system to use interpreters from /usr/local/bin or other directories according to system `PATH` variable
- Changed os.system call to use `clementine` instead of `/usr/bin/clementine`, same reasoning.
  - Keep in mind that os.system is deprecated, and you should probably consider using [subprocess.call](https://docs.python.org/3/library/subprocess.html#subprocess.call) instead, but I think that's probably out of scope for this particular PR
- Skips blank input lines (run the script and press enter, now it doesn't throw an exception)
- Handle `KeyboardInterrupt` and `EOFError` (Ctrl-C, Ctrl-D) a little more gracefully. Program still exits, just without throwing a traceback at the user.